### PR TITLE
tail scrollbars

### DIFF
--- a/islands/drawer/tail.tsx
+++ b/islands/drawer/tail.tsx
@@ -35,7 +35,7 @@ export const TailRow = (
   { row }: { row: TailData },
 ) => (
   <div className="flex flex-row w-full">
-    <div className="bg-black text-white py-2 px-4 text-sm overflow-x-scroll flex flex-col justify-start">
+    <div className="bg-black text-white py-2 px-4 text-sm overflow-x-scroll flex flex-col justify-start dark-scrollbar">
       <div className="text-stormCloud">
         {row.timestamp?.toLocaleDateString(
           "en-us",
@@ -173,7 +173,7 @@ export const Tail = ({ audience }: { audience: Audience }) => {
             fullScreen ? "100" : "90"
           }%] h-[calc(100vh-${
             fullScreen ? "200" : "260"
-          }px)] overflow-y-scroll rounded-md bg-black text-white`}
+          }px)] overflow-y-scroll rounded-md bg-black text-white dark-scrollbar`}
         >
           {tailSignal.value?.map((tail: TailData) => <TailRow row={tail} />)}
           <div ref={scrollBottom} />

--- a/static/style.css
+++ b/static/style.css
@@ -25,3 +25,16 @@ select {
   font-size: 12px;
 }
 
+/*
+  Make scrollbars less intrusive for those
+  who have scrollbars set to always show in OSX
+*/
+.dark-scrollbar::-webkit-scrollbar {
+  background-color: #000;
+}
+
+.dark-scrollbar::-webkit-scrollbar-thumb {
+  background: #aaa;
+  border-radius: 0.375rem;
+}
+


### PR DESCRIPTION
Webkit scrollbars are white be default so people who have scroll bars set to always show in OSX see this in tail:

<img width="1074" alt="Screenshot 2023-11-29 at 10 31 40 AM" src="https://github.com/streamdal/console/assets/191780/bfc16445-ea75-42e4-9170-a3072218d732">

I changed the default background color to black so they won't see anything unless there is something to scroll, in which case they will see a gray on black scrollable thumb:

<img width="954" alt="Screenshot 2023-11-29 at 11 01 25 AM" src="https://github.com/streamdal/console/assets/191780/79139ce2-3e3d-476f-9aa4-f05164611a6f">
<img width="464" alt="Screenshot 2023-11-29 at 11 01 12 AM" src="https://github.com/streamdal/console/assets/191780/d1a35dcd-9772-49d7-baac-7c9801abb185">
